### PR TITLE
Update Rust Makefile to disable LLVM CI download

### DIFF
--- a/SCRIPTS/02_prepare_package.sh
+++ b/SCRIPTS/02_prepare_package.sh
@@ -173,6 +173,7 @@ wget -qO- https://github.com/sbwml/r4s_build_script/raw/refs/heads/master/openwr
 popd
 # rust
 wget https://github.com/rust-lang/rust/commit/e8d97f0.patch -O feeds/packages/lang/rust/patches/e8d97f0.patch
+sed -i 's/--set=llvm\.download-ci-llvm=true/--set=llvm.download-ci-llvm=false/' feeds/packages/lang/rust/Makefile
 # mount cgroupv2
 pushd feeds/packages
 #patch -p1 <../../../PATCH/pkgs/cgroupfs-mount/0001-fix-cgroupfs-mount.patch


### PR DESCRIPTION
Disable LLVM CI download in Rust Makefile.